### PR TITLE
perf: improve the performance of thread_safe_queue

### DIFF
--- a/benchmarks/BUILD.bazel
+++ b/benchmarks/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_cpp//cpp:rules.bzl", "cpp_binary")
 cpp_binary(
     name = "benchmarks",
     srcs = [
+        "thread_safe_queue.cpp",
         "threading.cpp",
     ],
     deps = [

--- a/benchmarks/thread_safe_queue.cpp
+++ b/benchmarks/thread_safe_queue.cpp
@@ -1,0 +1,67 @@
+#include <benchmark/benchmark.h>
+
+#include <coroutine>
+#include <stop_token>
+#include <thread>
+
+import aid.containers;
+
+aid::thread_safe_queue<int> *g_test_queue;
+
+static void thread_safe_queue_push(benchmark::State &state) {
+  if (state.thread_index() == 0)
+    g_test_queue = new aid::thread_safe_queue<int>();
+
+  for (auto _ : state) {
+    g_test_queue->push(42);
+  }
+
+  if (state.thread_index() == 0)
+    delete g_test_queue;
+}
+
+static void thread_safe_queue_mpmc(benchmark::State &state) {
+  if (state.thread_index() == 0)
+    g_test_queue = new aid::thread_safe_queue<int>();
+
+  for (auto _ : state) {
+    if (state.thread_index() % 2 == 0)
+      g_test_queue->push(42);
+    else {
+      auto tmp = g_test_queue->pop();
+      benchmark::DoNotOptimize(tmp);
+    }
+  }
+
+  if (state.thread_index() == 0)
+    delete g_test_queue;
+}
+
+std::jthread *g_consumer_thread;
+
+static void thread_safe_queue_mpsc(benchmark::State &state) {
+  if (state.thread_index() == 0) {
+    g_test_queue = new aid::thread_safe_queue<int>();
+    g_consumer_thread = new std::jthread([](std::stop_token t) {
+      while (!t.stop_requested()) {
+        g_test_queue->wait(t);
+
+        g_test_queue->pop();
+      }
+    });
+  }
+
+  for (auto _ : state) {
+    g_test_queue->push(42);
+  }
+
+  if (state.thread_index() == 0) {
+    g_consumer_thread->request_stop();
+    delete g_consumer_thread;
+    delete g_test_queue;
+  }
+}
+
+BENCHMARK(thread_safe_queue_push)->ThreadRange(1, 12);
+BENCHMARK(thread_safe_queue_mpmc)->ThreadRange(2, 12);
+BENCHMARK(thread_safe_queue_mpsc)->ThreadRange(1, 12);

--- a/src/containers/BUILD.bazel
+++ b/src/containers/BUILD.bazel
@@ -1,21 +1,23 @@
 load("@rules_cpp//cpp:rules.bzl", "cpp_module")
 
 cpp_module(
-    name = "thread_safe_queue",
-    interface = "thread_safe_queue.cppm",
-    module_name = "aid.containers:thread_safe_queue",
-    deps = [
-        "//src/mutex",
-        "//src/utils",
-    ],
-)
-
-cpp_module(
     name = "vector",
     interface = "vector.cppm",
     module_name = "aid.containers:vector",
     deps = [
         "//src/memory",
+    ],
+)
+
+cpp_module(
+    name = "thread_safe_queue",
+    interface = "thread_safe_queue.cppm",
+    module_name = "aid.containers:thread_safe_queue",
+    deps = [
+        "//src/mutex",
+        "//src/memory",
+        "//src/utils",
+        ":vector",
     ],
 )
 

--- a/src/containers/thread_safe_queue.cppm
+++ b/src/containers/thread_safe_queue.cppm
@@ -2,52 +2,47 @@ module;
 
 #include <list>
 #include <optional>
+#include <stop_token>
 
 export module aid.containers:thread_safe_queue;
 
 import aid.mutex;
+import :vector;
 
 namespace aid {
+/// Multi-producer multi-consumer thread safe queue implementation.
 export template <typename T>
 class thread_safe_queue {
 public:
-  thread_safe_queue() : mQueue(std::list<T>()) {}
+  thread_safe_queue() : queue_(vector<T>()){};
+  thread_safe_queue(size_t capacity) : queue_(vector<T>()) {
+    queue_.with_lock([capacity](auto &queue) { queue.reserve(capacity); });
+  };
+
+  /// @brief Adds an element to the end of the queue.
+  /// @param value is a value to be placed on the queue.
   void push(T value) {
-    mQueue.with_lock([&](auto &queue) { queue.push_back(std::move(value)); });
-    mQueue.notify_one();
+    queue_.with_lock([&](auto &queue) {
+      queue.push_back(std::move(value));
+      bottom_++;
+    });
+    queue_.notify_one();
   }
 
+  /// @brief Extracts an element from the beginning of the queue.
+  /// @return std::nullopt if queue is empty, an element otherwise.
   std::optional<T> pop() {
     std::optional<T> ret;
 
-    mQueue.with_lock([&](auto &queue) {
-      if (!queue.empty()) {
-        ret.emplace(std::move(queue.front()));
-        queue.pop_front();
-      }
-    });
-
-    return ret;
-  }
-
-  bool empty() {
-    bool isEmpty = true;
-
-    mQueue.with_lock([&](auto &queue) { isEmpty = queue.empty(); });
-
-    return isEmpty;
-  }
-
-  template <typename F>
-  std::optional<T> find_if(F &&pred) {
-    std::optional<T> ret;
-
-    mQueue.with_lock([&](auto &queue) {
-      for (auto it = queue.begin(); it != queue.end(); ++it) {
-        if (pred(*it)) {
-          ret.emplace(std::move(*it));
-          queue.erase(it);
-          break;
+    queue_.with_lock([&](auto &queue) {
+      if (top_ != bottom_) {
+        ret.emplace(std::move(queue[top_++]));
+        if (top_ == bottom_) {
+          top_ = 0;
+          bottom_ = 0;
+          queue.clear();
+        } else {
+          defragment(queue);
         }
       }
     });
@@ -55,14 +50,55 @@ public:
     return ret;
   }
 
-  template <typename ST>
-  void wait(ST /*std::stop_token*/ token) {
-    const auto hasElement = [](const auto &queue) { return !queue.empty(); };
+  /// @brief Extracts an element from the beginning of the queue if lock is not
+  /// owned by anyone.
+  /// @return std::nullopt if retrieval failed, an element otherwise.
+  std::optional<T> try_pop() {
+    std::optional<T> ret;
 
-    mQueue.wait(hasElement, token);
+    queue_.try_with_lock([&](auto &queue) {
+      if (top_ != bottom_) {
+        ret.emplace(std::move(queue[top_++]));
+        if (top_ == bottom_) {
+          top_ = 0;
+          bottom_ = 0;
+          queue.clear();
+        } else {
+          defragment(queue);
+        }
+      }
+    });
+
+    return ret;
+  }
+
+  bool empty() const noexcept { return top_ == bottom_; }
+
+  /// @brief Blocking wait until an element is enqueued.
+  /// @param token is a cancellation token.
+  void wait(std::stop_token token) {
+    const auto had_element = [this](const auto &queue) {
+      return top_ != bottom_;
+    };
+
+    queue_.wait(had_element, token);
   }
 
 private:
-  condition_variable<std::list<T>> mQueue;
+  void defragment(vector<T> &queue) {
+    if (top_ < queue.capacity() / 3)
+      return;
+
+    for (size_t i = top_; i < bottom_; i++)
+      queue[i - top_] = std::move(queue[i]);
+
+    queue.erase(&queue[bottom_ - top_]);
+    top_ = 0;
+    bottom_ = queue.size();
+  }
+
+  condition_variable<vector<T>> queue_;
+  size_t top_ = 0;
+  size_t bottom_ = 0;
 };
 } // namespace aid

--- a/src/containers/vector.cppm
+++ b/src/containers/vector.cppm
@@ -62,6 +62,18 @@ public:
 
   virtual void resize(std::size_t count, const T &value = T()) = 0;
 
+  void clear() {
+    for (auto it = mStart; it != mEnd; ++it)
+      std::destroy_at(it);
+    mEnd = mStart;
+  }
+
+  void erase(iterator start) {
+    for (auto it = start; it != mEnd; ++it)
+      std::destroy_at(it);
+    mEnd = start;
+  }
+
 protected:
   vector_base() = default;
   explicit vector_base(size_t capacity) : mCapacity(capacity){};

--- a/src/mutex/exclusive.cppm
+++ b/src/mutex/exclusive.cppm
@@ -2,6 +2,7 @@ module;
 
 #include <functional>
 #include <mutex>
+#include <optional>
 
 export module aid.mutex:exclusive;
 
@@ -22,6 +23,24 @@ public:
   template <typename F>
   decltype(auto) with_lock(F &&f) const {
     std::unique_lock _{mMutex};
+    return std::invoke(std::forward<F>(f), mValue);
+  }
+
+  template <typename F>
+  std::optional<std::invoke_result_t<F, Value>> try_with_lock(F &&f) {
+    std::unique_lock lock{mMutex, std::try_to_lock};
+    if (!lock.owns_lock())
+      return std::nullopt;
+
+    return std::invoke(std::forward<F>(f), mValue);
+  }
+
+  template <typename F>
+  std::optional<std::invoke_result_t<F, Value>> try_with_lock(F &&f) const {
+    std::unique_lock lock{mMutex, std::try_to_lock};
+    if (!lock.owns_lock())
+      return std::nullopt;
+
     return std::invoke(std::forward<F>(f), mValue);
   }
 

--- a/tests/thread_safe_queue.cpp
+++ b/tests/thread_safe_queue.cpp
@@ -17,7 +17,4 @@ TEST_CASE("Basic methods work", "[thread_safe_queue]") {
   auto first = q.pop();
   REQUIRE(first.has_value());
   REQUIRE(*first == 1);
-  auto found = q.find_if([](int i) { return i == 4; });
-  REQUIRE(found.has_value());
-  REQUIRE(*found == 4);
 }


### PR DESCRIPTION
Switch to the usage of a contiguous storage rather than doubly linked lists. The new implementation is still not lock-free. The following benchmarks were completed on AMD Ryzen Threadripper 2920X 12-Core Processor.

Before

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
thread_safe_queue_push/threads:1         135 ns          135 ns      4590860
thread_safe_queue_push/threads:2         226 ns          378 ns      1852874
thread_safe_queue_push/threads:4         647 ns         1994 ns       386920
thread_safe_queue_push/threads:8        1078 ns         7160 ns       112248
thread_safe_queue_push/threads:12       1142 ns        11215 ns        65556
thread_safe_queue_mpmc/threads:2         243 ns          413 ns      1679348
thread_safe_queue_mpmc/threads:4         623 ns         1972 ns       272808
thread_safe_queue_mpmc/threads:8        1164 ns         7284 ns       138952
thread_safe_queue_mpmc/threads:12       1141 ns        10495 ns        58380
```

After:

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
thread_safe_queue_push/threads:1        49.7 ns         49.7 ns     14129683
thread_safe_queue_push/threads:2         222 ns          420 ns      2675590
thread_safe_queue_push/threads:4         306 ns         1032 ns       735052
thread_safe_queue_push/threads:8         432 ns         2901 ns       251744
thread_safe_queue_push/threads:12        475 ns         4896 ns       157848
thread_safe_queue_mpmc/threads:2         153 ns          290 ns      2000000
thread_safe_queue_mpmc/threads:4         273 ns          967 ns       711848
thread_safe_queue_mpmc/threads:8         377 ns         2597 ns       260416
thread_safe_queue_mpmc/threads:12        429 ns         4337 ns       120000
```